### PR TITLE
yt_dlp cherry-pick to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ![Docker Stars](https://img.shields.io/docker/stars/whatdaybob/sonarr_youtubedl?style=flat-square)
 [![Docker Hub](https://img.shields.io/badge/Open%20On-DockerHub-blue)](https://hub.docker.com/r/whatdaybob/sonarr_youtubedl)
 
-[whatdaybob/sonarr_youtubedl](https://github.com/whatdaybob/Custom_Docker_Images/tree/master/sonarr_youtubedl) is a [Sonarr](https://sonarr.tv/) companion script to allow the automatic downloading of web series normally not available for Sonarr to search for. Using [Youtube-DL](https://ytdl-org.github.io/youtube-dl/index.html) it allows you to download your webseries from the list of [supported sites](https://ytdl-org.github.io/youtube-dl/supportedsites.html).
+[whatdaybob/sonarr_youtubedl](https://github.com/whatdaybob/Custom_Docker_Images/tree/master/sonarr_youtubedl) is a [Sonarr](https://sonarr.tv/) companion script to allow the automatic downloading of web series normally not available for Sonarr to search for. Using [YT-DLP](https://github.com/yt-dlp/yt-dlp) (a youtube-dl fork with added features) it allows you to download your webseries from the list of [supported sites](https://github.com/yt-dlp/yt-dlp/blob/master/supportedsites.md).
 
 ## Features
 

--- a/app/sonarr_youtubedl.py
+++ b/app/sonarr_youtubedl.py
@@ -1,6 +1,6 @@
 import requests
 import urllib.parse
-import youtube_dl
+import yt_dlp
 import os
 import sys
 import re
@@ -309,7 +309,7 @@ class SonarrYTDL(object):
 
     def ytsearch(self, ydl_opts, playlist):
         try:
-            with youtube_dl.YoutubeDL(ydl_opts) as ydl:
+            with yt_dlp.YoutubeDL(ydl_opts) as ydl:
                 result = ydl.extract_info(
                     playlist,
                     download=False
@@ -393,7 +393,7 @@ class SonarrYTDL(object):
                                 logger.debug('Youtube-DL opts used for downloading')
                                 logger.debug(ytdl_format_options)
                             try:
-                                youtube_dl.YoutubeDL(ytdl_format_options).download([dlurl])
+                                yt_dlp.YoutubeDL(ytdl_format_options).download([dlurl])
                                 self.rescanseries(ser['id'])
                                 logger.info("      Downloaded - {}".format(eps['title']))
                             except Exception as e:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests==2.25.1
-youtube_dl==2021.6.6
+yt-dlp==2022.4.8
 pyyaml==5.4.1
 schedule==1.1.0


### PR DESCRIPTION
I couldn't get the dev branch to work for me, but the good news is that `yt_dlp` works as a (mostly) drop-in replacement on `main` and greatly sped up downloads.

Caveat emptor: My shared server doesn't allow docker, so I am running `app/sonarr_youtubedl.py` directly.