### PR TITLE
Fix ssl support and add basedir support

### DIFF
--- a/app/config.yml.template
+++ b/app/config.yml.template
@@ -1,11 +1,12 @@
 sonarrytdl:
-    scan_interval: 1 # minutes between scans
-    debug: False # Set to True for a more verbose output
+    scan_interval: 1  # minutes between scans
+    debug: False  # Set to True for a more verbose output
 sonarr:
     host: 192.168.1.123
-    port: 1234
+    port: 8989  # sonarr default port
     apikey: 12341234
     ssl: false
+    # basedir: '/sonarr'  # if you have sonarr running with a basedir set (e.g. behind a proxy)
 ytdl:
   # For information on format refer to https://github.com/ytdl-org/youtube-dl#format-selection
     default_format: bestvideo[width<=1920]+bestaudio/best[width<=1920]

--- a/app/sonarr_youtubedl.py
+++ b/app/sonarr_youtubedl.py
@@ -56,11 +56,12 @@ class SonarrYTDL(object):
         try:
             scheme = "http"
             if cfg['sonarr']['ssl']:
-                scheme == "https"
-            self.base_url = "{0}://{1}:{2}".format(
+                scheme = "https"
+            self.base_url = "{0}://{1}:{2}/{3}".format(
                 scheme,
                 cfg['sonarr']['host'],
-                str(cfg['sonarr']['port'])
+                str(cfg['sonarr']['port']),
+                cfg['sonarr'].get('basedir', '')
             )
             self.api_key = cfg['sonarr']['apikey']
         except Exception:


### PR DESCRIPTION
Adds support for a new `sonarr.basedir` option and fixes the `sonarr.ssl` option to work correctly