### PR TITLE
Bugfix: yt-dlp update and rescan command url fix.

### DIFF
--- a/app/sonarr_youtubedl.py
+++ b/app/sonarr_youtubedl.py
@@ -171,9 +171,8 @@ class SonarrYTDL(object):
             "seriesId": str(series_id)
         }
         res = self.request_put(
-            "{}/{}/command".format(self.base_url),
+            "{}/{}/command".format(self.base_url, self.sonarr_api_version),
             None, 
-            self.sonarr_api_version,
             data
         )
         return res.json()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests==2.28.2
-yt-dlp==2023.1.6
+yt-dlp==2023.3.4
 pyyaml==6.0
 schedule==1.1.0


### PR DESCRIPTION
Pulls in the latest version of yt-dlp, as the previous version reference contains a fatal bug.

Fix issue where the api version was being passed as a parameter to a put call instead of as a parameter to a string format call, causing rescanning of the series to fail with a "Replacement index 1 out of range for positional args tuple" error