### PR TITLE
Choose videos by name via fuzzy best-match

### DIFF
--- a/app/sonarr_youtubedl.py
+++ b/app/sonarr_youtubedl.py
@@ -4,7 +4,7 @@ import yt_dlp
 import os
 import sys
 import re
-from utils import upperescape, checkconfig, offsethandler, YoutubeDLLogger, ytdl_hooks, ytdl_hooks_debug, setup_logging  # NOQA
+from utils import upperescape, checkconfig, offsethandler, YoutubeDLLogger, ytdl_hooks, ytdl_hooks_debug, setup_logging, find_best_match_index  # NOQA
 from datetime import datetime
 import schedule
 import time
@@ -322,7 +322,7 @@ class SonarrYTDL(object):
             logger.debug(ytdlopts)
         return ytdlopts
 
-    def ytsearch(self, ydl_opts, playlist):
+    def ytsearch(self, ydl_opts, playlist, name):
         try:
             with yt_dlp.YoutubeDL(ydl_opts) as ydl:
                 result = ydl.extract_info(
@@ -335,7 +335,9 @@ class SonarrYTDL(object):
             video_url = None
             if 'entries' in result and len(result['entries']) > 0:
                 try:
-                    video_url = result['entries'][0].get('webpage_url')
+                    titles = [entry['title'].lower() for entry in result['entries']]
+                    index = find_best_match_index(titles, name.lower())
+                    video_url = result['entries'][index].get('webpage_url')
                 except Exception as e:
                     logger.error(e)
             else:
@@ -360,7 +362,7 @@ class SonarrYTDL(object):
                         if 'cookies_file' in ser:
                             cookies = ser['cookies_file']
                         ydleps = self.ytdl_eps_search_opts(upperescape(eps['title']), ser['playlistreverse'], cookies)
-                        found, dlurl = self.ytsearch(ydleps, url)
+                        found, dlurl = self.ytsearch(ydleps, url, name=ser['title']+' - '+eps['title'])
                         if found:
                             logger.info("    {}: Found - {}:".format(e + 1, eps['title']))
                             ytdl_format_options = {

--- a/app/sonarr_youtubedl.py
+++ b/app/sonarr_youtubedl.py
@@ -337,11 +337,11 @@ class SonarrYTDL(object):
                 try:
                     titles = [entry['title'].lower() for entry in result['entries']]
                     index = find_best_match_index(titles, name.lower())
-                    video_url = result['entries'][index].get('webpage_url')
+                    video_url = result['entries'][index].get('url')
                 except Exception as e:
                     logger.error(e)
             else:
-                video_url = result.get('webpage_url')
+                video_url = result.get('url')
             if playlist == video_url:
                 return False, ''
             if video_url is None:

--- a/app/utils.py
+++ b/app/utils.py
@@ -5,6 +5,7 @@ import datetime
 import yaml
 import logging
 from logging.handlers import RotatingFileHandler
+from fuzzywuzzy import fuzz
 
 
 CONFIGFILE = os.environ['CONFIGPATH']
@@ -159,3 +160,13 @@ def setup_logging(lf_enabled=True, lc_enabled=True, debugging=False):
         logger.addHandler(loggerconsole)
 
     return logger
+
+def find_best_match_index(titles, name):
+    best_match_index = -1
+    best_match_score = -1
+    for i, title in enumerate(titles):
+        score = fuzz.ratio(name, title)
+        if score > best_match_score:
+            best_match_index = i
+            best_match_score = score
+    return best_match_index

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ requests==2.28.2
 yt-dlp==2023.1.6
 pyyaml==6.0
 schedule==1.1.0
+fuzzywuzzy==0.18.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ yt-dlp==2023.1.6
 pyyaml==6.0
 schedule==1.1.0
 fuzzywuzzy==0.18.0
+python-Levenshtein=0.21.1


### PR DESCRIPTION
### Problem:
In some cases, the yt-search results in multiple videos being returned, but only one of them being the best-match.  
This isnt necessarily the latest or first one in the list of results.

### Changes to solve:
Added fuzzy-checking to the results and only select the best-match instead of the first one.

### Further changes:
Instwad of grabbing the webpage-url, the url of the video is seletec instead. This should stop some cases where only a flat-search was done, in this case, webpage-url always returns e.g. the playlist-url, not the video-url.