### PR TITLE
Add global extra_args for yt-dlp

### DIFF
--- a/app/config.yml.template
+++ b/app/config.yml.template
@@ -12,6 +12,13 @@ sonarr:
 ytdl:
   # For information on format refer to https://github.com/ytdl-org/youtube-dl#format-selection
     default_format: bestvideo[width<=1920]+bestaudio/best[width<=1920]
+
+  # Extra args for yt-dlp
+  #  see YoutubeDL class in https://github.com/ytdl-org/youtube-dl/blob/master/youtube_dl/YoutubeDL.py
+  extra_args:
+    # e.g. Enable flat-scraping (Dont follow links on pages)
+    #   Requires less connections and is thus much faster, but requires videos to be on the same page as the provided link e.g. playlists or youtube-channel-video-page (see example for 'The Slow Mo Guys')
+    extract_flat: True
 series:
   # Standard channel to check
   - title: Smarter Every Day
@@ -20,7 +27,7 @@ series:
   # For information on cookies refer to https://github.com/ytdl-org/youtube-dl#how-do-i-pass-cookies-to-youtube-dl
   # For information on format refer to https://github.com/ytdl-org/youtube-dl#format-selection
   - title: The Slow Mo Guys
-    url: https://www.youtube.com/channel/UCUK0HBIBWgM2c4vsPhkYY4w
+    url: https://www.youtube.com/channel/UCUK0HBIBWgM2c4vsPhkYY4w/videos
     cookies_file: youtube_cookies.txt # located in the same config folder
     format: bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best
   # Youtube playlist of latest season with time offset, useful for member videos having early release

--- a/app/config.yml.template
+++ b/app/config.yml.template
@@ -13,12 +13,12 @@ ytdl:
   # For information on format refer to https://github.com/ytdl-org/youtube-dl#format-selection
     default_format: bestvideo[width<=1920]+bestaudio/best[width<=1920]
 
-  # Extra args for yt-dlp
-  #  see YoutubeDL class in https://github.com/ytdl-org/youtube-dl/blob/master/youtube_dl/YoutubeDL.py
-  extra_args:
-    # e.g. Enable flat-scraping (Dont follow links on pages)
-    #   Requires less connections and is thus much faster, but requires videos to be on the same page as the provided link e.g. playlists or youtube-channel-video-page (see example for 'The Slow Mo Guys')
-    extract_flat: True
+    # Extra args for yt-dlp
+    #  see YoutubeDL class in https://github.com/ytdl-org/youtube-dl/blob/master/youtube_dl/YoutubeDL.py
+    extra_args:
+      # e.g. Enable flat-scraping (Dont follow links on pages)
+      #   Requires less connections and is thus much faster, but requires videos to be on the same page as the provided link e.g. playlists or youtube-channel-video-page (see example for 'The Slow Mo Guys')
+      extract_flat: True
 series:
   # Standard channel to check
   - title: Smarter Every Day

--- a/app/sonarr_youtubedl.py
+++ b/app/sonarr_youtubedl.py
@@ -91,8 +91,8 @@ class SonarrYTDL(object):
                             self.ytdl_extra_args[key] = int(value)
                         except ValueError:
                             self.ytdl_extra_args[key] = value
-        except Exception:
-            sys.exit("Error with ytdl config.yml values.")
+        except Exception as e:
+            sys.exit(f"Error with ytdl config.yml values: {e}")
 
         # YTDL Setup
         try:

--- a/app/sonarr_youtubedl.py
+++ b/app/sonarr_youtubedl.py
@@ -79,6 +79,19 @@ class SonarrYTDL(object):
         # YTDL Setup
         try:
             self.ytdl_format = cfg['ytdl']['default_format']
+
+            # Extra-args
+            if cfg['ytdl'].get('extra_args') == None:
+                self.ytdl_extra_args = dict()
+            else:
+                for key, value in cfg['ytdl']['extra_args']:
+                    if value.lower() in ('true', 'false'):
+                        self.ytdl_extra_args[key] = bool(value)
+                    else:
+                        try:
+                            self.ytdl_extra_args[key] = int(value)
+                        except ValueError:
+                            self.ytdl_extra_args[key] = value
         except Exception:
             sys.exit("Error with ytdl config.yml values.")
 
@@ -261,6 +274,9 @@ class SonarrYTDL(object):
                     ))
         return needed
 
+    def append_extra_args(self, ytdlopts):
+        return {**ytdlopts, **self.ytdl_extra_args}
+
     def appendcookie(self, ytdlopts, cookies=None):
         """Checks if specified cookie file exists in config
         - ``ytdlopts``: Youtube-dl options to append cookie to
@@ -317,6 +333,7 @@ class SonarrYTDL(object):
                 'progress_hooks': [ytdl_hooks],
             })
         ytdlopts = self.appendcookie(ytdlopts, cookies)
+        ytdlopts = self.append_extra_args(ytdlopts)
         if self.debug is True:
             logger.debug('Youtube-DL opts used for episode matching')
             logger.debug(ytdlopts)
@@ -378,6 +395,7 @@ class SonarrYTDL(object):
                                 'noplaylist': True,
                             }
                             ytdl_format_options = self.appendcookie(ytdl_format_options, cookies)
+                            ytdlopts = self.append_extra_args(ytdlopts)
                             if 'format' in ser:
                                 ytdl_format_options = self.customformat(ytdl_format_options, ser['format'])
                             if 'subtitles' in ser:

--- a/app/sonarr_youtubedl.py
+++ b/app/sonarr_youtubedl.py
@@ -81,10 +81,9 @@ class SonarrYTDL(object):
             self.ytdl_format = cfg['ytdl']['default_format']
 
             # Extra-args
-            if cfg['ytdl'].get('extra_args') == None:
-                self.ytdl_extra_args = dict()
-            else:
-                for key, value in cfg['ytdl']['extra_args']:
+            self.ytdl_extra_args = dict()
+            if cfg['ytdl'].get('extra_args') != None:
+                for key, value in cfg['ytdl']['extra_args'].items():
                     if value.lower() in ('true', 'false'):
                         self.ytdl_extra_args[key] = bool(value)
                     else:


### PR DESCRIPTION
Add config-section to allow adding extra-args to yt-dlp when executing actions.

This allows e.g. setting flat-search which is much much faster and requires less requests to be done in cases where the videos are directly listed on the provided page e.g. playlists.

Flat-search was also enabled by-default to have everyone benefit from the performance-increase, including warnings on its limitations and how to properly use it.  
As most shows are probably in the videos-section of a channel or playlists directly, there shouldnt be a need for everyone to deep-search a whole channel or videos in a playlist (even less reason)