### PR TITLE
Update to make Sonarr source of truth for resolution/file naming

### DIFF
--- a/app/config.yml.template
+++ b/app/config.yml.template
@@ -6,8 +6,10 @@ sonarr:
     port: 8989  # sonarr default port
     apikey: 12341234
     ssl: false
+    path: "" # Path as defined by library directory for Sonarr
+    localpath: "/sonarr_root" # Path to Sonarr library as seen by local system
     # basedir: '/sonarr'  # if you have sonarr running with a basedir set (e.g. behind a proxy)
-    # version: v4 # if running v4 beta, allows the v3 api endpoints
+    version: v4 # if running v4 beta or current v3, allows the v3 api endpoints
 
 ytdl:
   # For information on format refer to https://github.com/ytdl-org/youtube-dl#format-selection

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-requests==2.28.2
-yt-dlp==2023.1.6
-pyyaml==6.0
-schedule==1.1.0
+requests>=2.28.2
+yt-dlp>=2023.1.6
+pyyaml>=6.0
+schedule>=1.1.0


### PR DESCRIPTION
Uses the qualityProfileId to determine the maximum resolution wanted in order to convert the height to width for building the yt-dlp format string.

Uses the SeasonFolderFormat and numberStyle for Sonarr to build the directory structure and file naming.

Add support for differing paths between Sonarr and sonarr_youtubedl

Allow for newer packages... 