### PR TITLE
Make parenthesis and the text in it optional and support zero to multiple spaces

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -19,13 +19,20 @@ def upperescape(string):
         ``string``: str new string
     """
     # UPPERCASE as YTDL is case insensitive for ease.
-    string = string.upper() 
+    string = string.upper()
     # Remove quote characters as YTDL converts these.
-    string = string.replace('’',"'") 
+    string = string.replace('’',"'")
     string = string.replace('“','"')
     string = string.replace('”','"')
+    # Replace >1 space with single space
+    string = re.sub(" +", " ", string)
     # Escape the characters
     string = re.escape(string)
+    # Handle none to multiple spaces
+    string = string.replace("\\ ", "[\\ ]*")
+    # Make parenthesis optional
+    string = string.replace("\\(", "([\\(]?")
+    string = string.replace("\\)", "[\\)]?)?")
     # Make it look for and as whole or ampersands
     string = string.replace('\\ AND\\ ','\\ (AND|&)\\ ')
     # Make punctuation optional for human error
@@ -131,7 +138,7 @@ def ytdl_hooks(d):
 
 def setup_logging(lf_enabled=True, lc_enabled=True, debugging=False):
     log_level = logging.INFO
-    log_level = logging.DEBUG if debugging == True else log_level
+    log_level = logging.DEBUG if debugging is True else log_level
     logger = logging.getLogger('sonarr_youtubedl')
     logger.setLevel(log_level)
     log_format = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')


### PR DESCRIPTION
To improve matching, make the parenthesis themselves as well as the text inside the parenthesis optional. Also allows for zero to multiple spaces between words.