### PR TITLE
Make requirements minimums

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-requests==2.28.2
-yt-dlp==2023.03.04
-pyyaml==6.0
-schedule==1.1.0
+requests>=2.28.2
+yt-dlp>=2023.03.04
+pyyaml>=6.0
+schedule>=1.1.0


### PR DESCRIPTION
Should allow the packages, especially yt-dlp, to be current whenever the docker is built.